### PR TITLE
Fix README badges layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # 🌿 OpsGarden – A DevOps Playground on AWS
 
-[![CI Build](https://github.com/GitCubeStella/ops-garden/actions/workflows/docker-build.yml/badge.svg)](https://github.com/GitCubeStella/ops-garden/actions)
-[![Run Tests](https://github.com/GitCubeStella/ops-garden/actions/workflows/docker-test.yml/badge.svg)](https://github.com/GitCubeStella/ops-garden/actions)
+[![CI Build](https://github.com/GitCubeStella/ops-garden/actions/workflows/docker-build.yml/badge.svg)](https://github.com/GitCubeStella/ops-garden/actions) [![Run Tests](https://github.com/GitCubeStella/ops-garden/actions/workflows/docker-test.yml/badge.svg)](https://github.com/GitCubeStella/ops-garden/actions)
 
 **OpsGarden** ist ein hands-on DevOps-Demoprojekt, das zeigt, wie man Microservices lokal entwickelt und später in eine skalierbare AWS-Umgebung (EKS) deployt – mit Fokus auf CI/CD, Infrastructure as Code und Observability.
 


### PR DESCRIPTION
## Summary
- combine build and test badges into a single line to avoid URL line breaks

## Testing
- `pip install -r app/notes-service/requirements.txt`
- `cd app/notes-service && pytest`


------
https://chatgpt.com/codex/tasks/task_e_689069930318832786987e46def22842