### PR TITLE
feat: support postgres env vars

### DIFF
--- a/app/notes-service/database.py
+++ b/app/notes-service/database.py
@@ -3,11 +3,22 @@ import os
 
 engine = None
 
+
 def get_engine():
     global engine
     if engine is None:
-        DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./test.db")
-        engine = create_engine(DATABASE_URL, echo=True)
+        database_url = os.getenv("DATABASE_URL")
+        if not database_url:
+            host = os.getenv("DB_HOST")
+            port = os.getenv("DB_PORT")
+            name = os.getenv("DB_NAME")
+            user = os.getenv("DB_USER")
+            password = os.getenv("DB_PASSWORD")
+            if all([host, port, name, user, password]):
+                database_url = f"postgresql://{user}:{password}@{host}:{port}/{name}"
+            else:
+                database_url = "sqlite:///./test.db"
+        engine = create_engine(database_url, echo=True)
     return engine
 
 def get_session():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     depends_on:
       - db
     environment:
+      # DATABASE_URL takes precedence over these values
       - DB_HOST=db
       - DB_PORT=5432
       - DB_NAME=notes


### PR DESCRIPTION
## Summary
- build database engine from `DATABASE_URL` or Postgres env vars with SQLite fallback
- document that `DATABASE_URL` takes precedence in docker-compose

## Testing
- `pytest app/notes-service -q`


------
https://chatgpt.com/codex/tasks/task_e_6890ea5b3f1c83279574290462d2bbdd