### PR TITLE
Handle in-memory SQLite connections

### DIFF
--- a/app/notes_service/database.py
+++ b/app/notes_service/database.py
@@ -1,4 +1,5 @@
 from sqlmodel import SQLModel, Session, create_engine
+from sqlalchemy.pool import StaticPool
 import os
 
 engine = None
@@ -18,7 +19,13 @@ def get_engine():
                 database_url = f"postgresql://{user}:{password}@{host}:{port}/{name}"
             else:
                 database_url = "sqlite:///./test.db"
-        engine = create_engine(database_url, echo=True)
+        if database_url.startswith("sqlite"):
+            kwargs = {"echo": True, "connect_args": {"check_same_thread": False}}
+            if database_url.endswith(":memory:"):
+                kwargs["poolclass"] = StaticPool
+            engine = create_engine(database_url, **kwargs)
+        else:
+            engine = create_engine(database_url, echo=True)
     return engine
 
 def get_session():

--- a/app/notes_service/test_in_memory.py
+++ b/app/notes_service/test_in_memory.py
@@ -1,0 +1,17 @@
+def test_in_memory_sqlite(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    from importlib import reload
+    import database
+    reload(database)
+    import main
+    reload(main)
+    from fastapi.testclient import TestClient
+    with TestClient(main.app) as client:
+        note = {"title": "MemTest", "content": "Using memory"}
+        response = client.post("/notes_service", json=note)
+        assert response.status_code == 200
+        assert response.json()["title"] == "MemTest"
+        get_response = client.get("/notes_service")
+        assert get_response.status_code == 200
+        assert len(get_response.json()) == 1
+    database.engine = None


### PR DESCRIPTION
## Summary
- ensure SQLite engine works with in-memory URLs by adding `StaticPool` and disabling thread checks
- add regression test for in-memory SQLite usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891ef3e151c8327b81c728ff81debaf